### PR TITLE
Basic Windows scripts

### DIFF
--- a/createADADmins.ps1
+++ b/createADADmins.ps1
@@ -1,0 +1,46 @@
+#Create a PowerShell Script that creates an Active Directory domain administrative account for each member of the Windows team.
+#This script should take a list of usernames as input and create a new user account in Active Directory with the appropriate permissions.
+
+
+# Loop through each username and create the user account
+# Import the AD module (if not already loaded)
+Import-Module ActiveDirectory
+
+# Define the list of usernames
+$usernames = @("user1", "user2", "user3") # Replace with actual usernames
+
+
+# Automatically detect the current domain
+$domain = (Get-ADDomain).DNSRoot  # e.g., "example.com"
+
+# Automatically detect the default Users OU or create a path dynamically
+$defaultOU = (Get-ADDomain).UsersContainer  # usually "CN=Users,DC=example,DC=com"
+
+# Optionally get the domain's NetBIOS name (for groups like "Domain Admins")
+$netbios = (Get-ADDomain).NetBIOSName
+
+foreach ($username in $usernames) {
+    # Build a standard display name
+    $displayName = "$($username.Substring(0,1).ToUpper())$($username.Substring(1))"
+
+    # Create the user
+    New-ADUser `
+        -Name $username `
+        -SamAccountName $username `
+        -UserPrincipalName "$username@$domain" `
+        -GivenName $username `
+        -Surname "User" `
+        -DisplayName $displayName `
+        -Path $defaultOU `
+        -AccountPassword (ConvertTo-SecureString "P@ssw0rd" -AsPlainText -Force) `
+        -ChangePasswordAtLogon $true `
+        -Enabled $true
+
+    # Add the user to the Domain Admins group dynamically
+    $domainAdminsDN = (Get-ADGroup -Filter { Name -eq "Domain Admins" }).DistinguishedName
+
+    Add-ADGroupMember -Identity $domainAdminsDN -Members $username
+
+    Write-Host "Created user $username and added to Domain Admins group."
+
+}

--- a/disablelocalaccounts.ps1
+++ b/disablelocalaccounts.ps1
@@ -1,0 +1,15 @@
+#Create a PowerShell script that disables and changes the password of every local Windows account on a non-domain controller Windows machine.
+
+# Get a list of all local user accounts
+$localUsers = Get-LocalUser
+
+foreach ($user in $localUsers) {
+    # Disable the user account
+    Disable-LocalUser -Name $user.Name
+
+    # Change the password
+    $newPassword = ConvertTo-SecureString "NewP@ssw0rd" -AsPlainText -Force
+    Set-LocalUser -Name $user.Name -Password $newPassword
+
+    Write-Host "Disabled account $($user.Name) and changed password."
+}


### PR DESCRIPTION
2 scrips 
1.  Creates AD accounts and gives them a default password that needs to be immediately changed along with making them domain admins. May add enterprise admins as well in the future based on discussion with Orlando if this is necessary. Script was tested in PowerShell with AD and was successful. Nothing is hard coded besides user names allowing for this to be easily used in competition and in the future

2. Disables local accounts and changes their passwords, will need to be editited later to ensure more complex passwords are used!